### PR TITLE
Add yarn dev command to run entrypoint locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Set with a 7 day expiry & ONLY give read only access to repos.
+
+LOCAL_GITHUB_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ jobs:
 
 ```
 
-## Running locally
+## Development
 
-You can run the script locally by executing `yarn start`. Note that you will need to pass in any environment variables normally passed in by the GitHub action when doing so.
+You can run the script locally by doing the following:
+1. Mocking the data in `entrypoint.dev.ts` so that it points towards another pull request you have access to
+2. Renaming `.env.example` to `.env` and providing your own token.
+3. Running `yarn dev`. 
 
 
 ## Disclaimer

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gepety-scan-action",
   "scripts": {
-    "start": "tsc && node dist/entrypoint.js",
-    "build": "tsc"
+    "build": "tsc",
+    "dev": "tsc && node dist/entrypoint.dev.js"
   },
   "engines": {
     "node": "^18 || ^20 || ^22"
@@ -20,6 +20,7 @@
     "@types/node": "^20.10.5"
   },
   "devDependencies": {
+    "dotenv": "^16.3.1",
     "typescript": "^5.3.3"
   }
 }

--- a/src/entrypoint.dev.ts
+++ b/src/entrypoint.dev.ts
@@ -1,0 +1,63 @@
+import { GitHubClient, GitHubContext, PullRequestData } from "./types";
+import { getOctokit } from "@actions/github";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const entrypoint = require('./entrypoint');
+const client: GitHubClient = getOctokit(process.env.LOCAL_GITHUB_ACCESS_TOKEN!);
+const mockPullRequestData: PullRequestData = {
+  number: 1,
+  head: {
+    // branch that we assume this is running on
+    ref: "gpt-test",
+    repo: {
+      full_name: "MetaMask/Appsec-Playground",
+      name: "Appsec-Playground",
+      owner: {
+        login: "MetaMask",
+      },
+    },
+  },
+  base: {
+    // Branch we assume the PR is merging against
+    ref: "main",
+    repo: {
+      full_name: "MetaMask/Appsec-Playground",
+      name: "Appsec-Playground",
+      owner: {
+        login: "MetaMask",
+      },
+    },
+  },
+};
+
+const context = {
+    "payload": {
+      "pull_request": mockPullRequestData,
+    },
+    "eventName": "pull_request",
+    "sha": "",
+    "ref": "",
+    "workflow": "Invoke Gepety Scan Action",
+    "action": "",
+    "actor": "",
+    "job": "build",
+    "runNumber": 6,
+    "runId":1,
+    "apiUrl": "https://api.github.com",
+    "serverUrl": "https://github.com",
+    "graphqlUrl": "https://api.github.com/graphql",
+    "issue": {},
+    "repo": {
+      "owner": "MetaMask",
+      "repo": "Appsec-Playground",
+      "repoUrl": "", 
+    }
+};
+
+console.log("----Running entrypoint locally to simulate a pull request opened");
+
+entrypoint({ github: client, context: context }).then(() => {
+  console.log("----Done");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,11 @@ deprecation@^2.0.0:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"


### PR DESCRIPTION
## Summary

This pull request mocks out the data that would normally be provided by a GitHub action, and replaces it with data pointing towards a blank playground repository.

The script will then pass the mock data into the regular entrypoint, and execute the actions as per usual.